### PR TITLE
removed hardcoded config value

### DIFF
--- a/verity/src/helm/Chart.yaml
+++ b/verity/src/helm/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.9.0

--- a/verity/src/helm/templates/configmap.yaml
+++ b/verity/src/helm/templates/configmap.yaml
@@ -155,7 +155,6 @@ data:
     </configuration>
   ledgers.conf: |
     {{- if .Values.taa }}
-    verity.lib-vdrtools.ledger.indy.transaction_author_agreement.enabled = false #TODO disabled to let application to start
     verity.lib-vdrtools.ledger.indy.transaction_author_agreement.agreements = {
       {{- range .Values.taa }}
       "{{ .version }}" {


### PR DESCRIPTION
The following line in the `helm/templates/configmap.yaml` file was added for development purposes and not required anymore:

    verity.lib-vdrtools.ledger.indy.transaction_author_agreement.enabled = false